### PR TITLE
added German translation

### DIFF
--- a/modules/ac_module_internals/out/admin/de/ac_module_internalls_lang.php
+++ b/modules/ac_module_internals/out/admin/de/ac_module_internalls_lang.php
@@ -7,40 +7,38 @@
 
 $sLangName = "Deutsch";
 
-//TODO: Add Real translations !
-
 $aLang = array(
     'charset' => 'ISO-8859-15',
 
-    'tbclmodule_internals_metadata' => '[de] Metadata',
-    'tbclmodule_internals_state'    => '[de] State',
-    'tbclmodule_internals_utils'    => '[de] Utils',
+    'tbclmodule_internals_metadata' => 'Metadaten',
+    'tbclmodule_internals_state'    => 'Status',
+    'tbclmodule_internals_utils'    => 'Hilfsmittel',
 
-    'AC_MI_VERSION'    => '[de] Version',
-    'AC_MI_EXTEND'     => '[de] Extended Classes',
-    'AC_MI_FILES'      => '[de] Files',
-    'AC_MI_BLOCKS'     => '[de] Template Blocks',
-    'AC_MI_TEMPLATES'  => '[de] Templates',
-    'AC_MI_SETTINGS'   => '[de] Settings',
-    'AC_MI_EVENTS'     => '[de] Events',
-    'AC_MI_CACHE'      => '[de] Module cache',
-    'AC_MI_ACTIVATION' => '[de] Module Activation / Deactivation',
+    'AC_MI_VERSION'    => 'Version',
+    'AC_MI_EXTEND'     => 'Erweiterte Klassen',
+    'AC_MI_FILES'      => 'Dateien',
+    'AC_MI_BLOCKS'     => 'Template-Blöcke',
+    'AC_MI_TEMPLATES'  => 'Templates',
+    'AC_MI_SETTINGS'   => 'Optionen',
+    'AC_MI_EVENTS'     => 'Ereignisse',
+    'AC_MI_CACHE'      => 'Modul Cache',
+    'AC_MI_ACTIVATION' => 'Modul-Aktivierung/-Deaktivierung',
 
-    'AC_MI_FIXBTN'         => '[de] Fix',
-    'AC_MI_RESETBTN'       => '[de] Reset',
-    'AC_MI_ACTIVATEBTN'    => '[de] Activate',
-    'AC_MI_DEACTIVATEBTN'  => '[de] Deactivate',
+    'AC_MI_FIXBTN'         => 'Fix',
+    'AC_MI_RESETBTN'       => 'Zurücksetzen',
+    'AC_MI_ACTIVATEBTN'    => 'Aktivieren',
+    'AC_MI_DEACTIVATEBTN'  => 'Deaktivieren',
 
-    'AC_LEGEND' => '[de] Legend',
-    'AC_STATE_OK'  => '[de] OK',
-    'AC_STATE_WA'  => '[de] Warning',
-    'AC_STATE_ER'  => '[de] Error',
-    'AC_STATE_FM'  => 'vFatal M',
-    'AC_STATE_FS'  => '[de] Fatal S',
+    'AC_LEGEND' => 'Legende',
+    'AC_STATE_OK'  => 'OK',
+    'AC_STATE_WA'  => 'Warnung',
+    'AC_STATE_ER'  => 'Fehler',
+    'AC_STATE_FM'  => 'Fehler M',
+    'AC_STATE_FS'  => 'Fehler S',
 
-    'AC_STATE_OK_LABEL'  => '[de] Metadata matches data stored in shop',
-    'AC_STATE_WA_LABEL'  => '[de] Metadata missing in shop data',
-    'AC_STATE_ER_LABEL'  => '[de] Shop data not found in metadata',
-    'AC_STATE_FM_LABEL'  => '[de] Files defined in metadata does not exist',
-    'AC_STATE_FS_LABEL'  => '[de] Files defined in shop data does not exist'
+    'AC_STATE_OK_LABEL'  => 'Die Metadaten entsprechen den Daten, die im Shop gespeichert sind.',
+    'AC_STATE_WA_LABEL'  => 'Metadaten fehlen in den Shop-Daten',
+    'AC_STATE_ER_LABEL'  => 'Shop-Daten wurden nicht in den Metadaten gefunden',
+    'AC_STATE_FM_LABEL'  => 'Die Dateien, die in den Metadaten definiert wurden, gibt es nicht',
+    'AC_STATE_FS_LABEL'  => 'Die Dateien, die in den Shop-Daten definiert wurden, gibt es nicht'
 );


### PR DESCRIPTION
"Fatal S" and "Fatal M" shall be re-named in English to "Fatal Error" or similar. Would also be good to have an explanation what "S" and "M" means ;)
