### PR TITLE
Backward compatibility fix.

### DIFF
--- a/core/ac_module_internals_data_helper.php
+++ b/core/ac_module_internals_data_helper.php
@@ -211,7 +211,12 @@ class ac_module_internals_data_helper
     {
         $sModulePath = $this->getModulePath();
         $aMetadataExtend = $this->getInfo('extend');
-        $aAllModules = oxRegistry::getConfig()->getModulesWithExtendedClass();
+        $oxidConfig = oxRegistry::getConfig();
+        if (method_exists($oxidConfig, 'getModulesWithExtendedClass')) {
+            $aAllModules = $oxidConfig->getModulesWithExtendedClass();
+        } else {
+            $aAllModules = $oxidConfig->getAllModules();
+        }
 
         $aResult = array();
         $sModulesDir = oxRegistry::getConfig()->getModulesDir(true);


### PR DESCRIPTION
The method oxConfig::getAllModules() was renamed to oxConfig::getModulesWithExtendedClass() in OXID eShop version 5.2.
Adding a check for the existance of  the method oxConfig::getModulesWithExtendedClass() will keep it working before OXID eShop version 5.2.