### PR TITLE
this add blocknames to the state tab of modules in the admin backend

### DIFF
--- a/core/ac_module_internals_data_helper.php
+++ b/core/ac_module_internals_data_helper.php
@@ -297,7 +297,7 @@ class ac_module_internals_data_helper
                     $iState = -2;
                 }
 
-                $aResult[$aBlock['template']][$aBlock['file']]['file'] = $iState;
+                $aResult[$aBlock['template']][$aBlock['block']][$aBlock['file']]['file'] = $iState;
             }
         }
 
@@ -307,13 +307,13 @@ class ac_module_internals_data_helper
 
                 $sBaseFile = basename($aDbBlock['OXFILE']);
 
-                if (!isset($aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXFILE']])) {
-                    $aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXFILE']] = -1;
+                if (!isset($aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXBLOCKNAME']][$aDbBlock['OXFILE']])) {
+                    $aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXBLOCKNAME']][$aDbBlock['OXFILE']]['file'] = -1;
                     if (!file_exists($sModulesDir . '/' . $sModulePath . '/' . $aDbBlock['OXFILE']) &&
                         !file_exists($sModulesDir . '/' . $sModulePath . '/out/blocks/' . $sBaseFile) &&
                         !file_exists($sModulesDir . '/' . $sModulePath . '/out/blocks/' . $sBaseFile) . '.tpl'
                     ) {
-                        $aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXFILE']]['file'] = -3;
+                        $aResult[$aDbBlock['OXTEMPLATE']][$aDbBlock['OXBLOCKNAME']][$aDbBlock['OXFILE']]['file'] = -3;
                     }
                 }
             }
@@ -342,11 +342,11 @@ class ac_module_internals_data_helper
                 }
 
                 if (empty($sTemplate)) {
-                    $aResult[$aBlock['template']][$aBlock['file']]['template'] = -3;
+                    $aResult[$aBlock['template']][$aBlock['block']][$aBlock['file']]['template'] = -3;
                 } else {
                     $sContent = file_get_contents($sTemplate);
                     if (!preg_match('/\[{.*block.* name.*= *"' . $aBlock['block'] . '".*}\]/', $sContent)) {
-                        $aResult[$aBlock['template']][$aBlock['file']]['template'] = -1;
+                        $aResult[$aBlock['template']][$aBlock['block']][$aBlock['file']]['block'] = -3;
                     }
                 }
             }

--- a/views/admin/tpl/ac_module_internals_state.tpl
+++ b/views/admin/tpl/ac_module_internals_state.tpl
@@ -93,25 +93,32 @@
     <h3>[{oxmultilang ident="AC_MI_BLOCKS"}]</h3>
     <table>
         [{assign var="_ok" value=1}]
-        [{foreach from=$aBlocks key=sTemplate item=aFiles}]
-        <tr>
-            [{assign var="_tstate" value=1}]
-            [{foreach from=$aFiles key=sFile item=aStates}]
-                [{if $aStates.template < $_tstate}]
-                    [{assign var="_tstate" value=$aStates.template}]
-                [{/if}]
-            [{/foreach}]
-            <td style="vertical-align: top;"><b><span class="state [{$sState.$_tstate}]">[{$sTemplate}]</span></b></td>
-            <td>
+        [{foreach from=$aBlocks key=sTemplate item=aBlockNames}]
+            [{foreach from=$aBlockNames key=sBlockName item=aFiles}]
+            <tr>
+                [{assign var="_tstate" value=1}]
+                [{assign var="_bstate" value=1}]
                 [{foreach from=$aFiles key=sFile item=aStates}]
-                [{assign var="_state" value=$aStates.file}]
-                <div>
-                    <span class="state [{$sState.$_state}]">[{$sFile}]</span>
-                    [{if $_state < 1 && $_state != -2 }][{assign var="_ok" value=0}][{/if}]
-                </div>
+                    [{if $aStates.template < $_tstate}]
+                        [{assign var="_tstate" value=$aStates.template}]
+                    [{/if}]
+                    [{if $aStates.block < $_bstate}]
+                        [{assign var="_bstate" value=$aStates.block}]
+                    [{/if}]
                 [{/foreach}]
-            </td>
-        </tr>
+                <td style="vertical-align: top;"><b><span class="state [{$sState.$_tstate}]">[{$sTemplate}]</span></b></td>
+                <td style="vertical-align: top;"><b><span class="state [{$sState.$_bstate}]">[{$sBlockName}]</span></b></td>
+                <td>
+                    [{foreach from=$aFiles key=sFile item=aStates}]
+                    [{assign var="_state" value=$aStates.file}]
+                    [{if $_state < 1 && $_state != -2 }][{assign var="_ok" value=0}][{/if}]
+                    <div>
+                        <span class="state [{$sState.$_state}]">[{$sFile}]</span>
+                    </div>
+                    [{/foreach}]
+                </td>
+            </tr>
+            [{/foreach}]
         [{/foreach}]
     </table>
     [{if !$_ok}]


### PR DESCRIPTION
It makes things easier to debug and understand if the blockname is listed:
![blocknames](https://cloud.githubusercontent.com/assets/7767623/13225825/e9b2aad2-d98e-11e5-8b4f-474fe47ac726.png)
