### PR TITLE
this alllows camelcase in metadata

### DIFF
--- a/core/ac_module_internals_data_helper.php
+++ b/core/ac_module_internals_data_helper.php
@@ -224,6 +224,7 @@ class ac_module_internals_data_helper
         // Check if all classes are extended.
         if (is_array($aMetadataExtend)) {
             $aMetadataExtend = array_change_key_case($aMetadataExtend, CASE_LOWER);
+            $aAllModules = array_change_key_case($aAllModules, CASE_LOWER);
             foreach ($aMetadataExtend as $sClassName => $sModuleName) {
                 $iState = 0;
                 if (is_array($aAllModules) && isset($aAllModules[$sClassName])) {


### PR DESCRIPTION
```
'extend'      => array(
        'oxReverseProxyBackend'   => 'oxps/esituning/core/oxpsesituning_oxreverseproybackend',
),
```

instead of

```
'extend'      => array(
        'oxreverseproxybackend'   => 'oxps/esituning/core/oxpsesituning_oxreverseproybackend',
),
```