### PR TITLE
check module extensions file exists in a case sensitive way

### DIFF
--- a/core/ac_module_internals_data_helper.php
+++ b/core/ac_module_internals_data_helper.php
@@ -233,10 +233,22 @@ class ac_module_internals_data_helper
                     }
                 }
 
-                if (!file_exists($sModulesDir . $sModuleName . ".php")) {
+                $sExtensionPath = $sModulesDir . $sModuleName . ".php";
+                if (!file_exists($sExtensionPath)) {
                     $aResult[$sClassName][$sModuleName] = -2; // sfatalm
                 } else {
-                    $aResult[$sClassName][$sModuleName] = $iState;
+                    $dir = dirname($sExtensionPath);
+                    $file = basename($sExtensionPath);
+
+                    //check if filename case sensitive so we will see errors
+                    //also on case insensitive filesystems
+                    if(in_array($file,scandir($dir))) {
+                        $aResult[$sClassName][$sModuleName] = $iState;
+                    } else {
+                        //file case does not match mark this because on other systems
+                        //this file will not be found
+                        $aResult[$sClassName][$sModuleName] = -2; // sfatalm
+                    }
                 }
             }
         }


### PR DESCRIPTION
usecase:
- working on a windows mashine with an vagrant box, so i have a case insensitive file system,
  - the FS used by windows is able to store files case sensitive but will find files even if the case does match.
- file exists check used in module internals tell everything is ok, even if the case of the filename does not match
- on deployment on integration system my module did not work because case of the file did not match because the unix server has a case sensitive file system
